### PR TITLE
feat: Add method to set client in runtime

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -75,6 +75,10 @@ void SSLClient::stop()
     SSLClientLib::stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
 }
 
+void SSLClient::setClient(Client* client) {
+    sslclient->client = client;
+}
+
 int SSLClient::connect(IPAddress ip, uint16_t port)
 {
     if (_pskIdent && _psKey)

--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -47,6 +47,7 @@ public:
     SSLClient(Client* client);
     ~SSLClient();
 
+    void setClient(Client* client);
     int connect(IPAddress ip, uint16_t port);
     int connect(IPAddress ip, uint16_t port, int32_t timeout);
     int connect(const char *host, uint16_t port);


### PR DESCRIPTION
## Description
Add method `setClient` to allow changing the client in runtime.

## Motivation and context
The need to allow changing between `WiFiClient ` and `TinyGsmClient` without having to create another `SSLClient` instance.

## How this has been tested?
**Tested with**:
- Hardware: ESP32-WROVER-IE 16MB, SIM7600G-H