### PR TITLE
chore: Change library names due to conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">
   <a><img src=".img/ssl.png" alt="Logo" width="400"></a>
   <br>
-  SSLClient for ESP32
+  SSLClientESP32
 </h1>
 
 <p align="center">
@@ -22,7 +22,7 @@
 ---
 
 ## Description
-The **SSLClient** library allows establishing a secure connection using SSL/TLS. Has been designed
+The **SSLClientESP32** library allows establishing a secure connection using SSL/TLS. Has been designed
 for ESP32. Allows you to give a secure connection to any object derived from `Client`, such as
 [WiFiClient](https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFi) and [TinyGsmClient](https://github.com/vshymanskyy/TinyGSM). Offers to be able to attach a [Certificate Bundle](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFiClientSecure/README.md#using-a-bundle-of-root-certificate-authority-certificates) to the client, reducing the
 number of certificates entered manually into the firmware and increasing the possibility of
@@ -33,18 +33,23 @@ Here are some basic examples...
 
 ### Adding library to platformio.ini (PlatformIO)
 ```ini
+; Most recent changes
 lib_deps =
-  https://github.com/alkonosst/SSLClient.git
+  https://github.com/alkonosst/SSLClientESP32.git
+
+; Release vx.y.z
+lib_deps =
+  https://github.com/alkonosst/SSLClientESP32.git#v2.0.0
 ```
 
 ### Using WiFi and Root Certificate to client
 ```cpp
 #include <WiFi.h>
-#include "SSLClient.h"
+#include "SSLClientESP32.h"
 
 // Create clients
 WiFiClient base_client;
-SSLClient ssl_client(&base_client);
+SSLClientESP32 ssl_client(&base_client);
 
 // Root Certificate ISRG Root X1
 const char* isrg_root_ca = "-----BEGIN CERTIFICATE-----\n"
@@ -80,14 +85,14 @@ board_build.embed_files = data/crt/x509_crt_bundle.bin
 ```cpp
 #include <WiFi.h>
 #include "TinyGSM.h"
-#include "SSLClient.h"
+#include "SSLClientESP32.h"
 
 // Modem SIM7600G-H
 TinyGsm modem(Serial1);
 
 // Create clients
 TinyGsmClient base_client(modem);
-SSLClient ssl_client(&base_client);
+SSLClientESP32 ssl_client(&base_client);
 
 // Declaration of binary file
 extern const uint8_t ca_cert_bundle_start[] asm("_binary_data_crt_x509_crt_bundle_bin_start");
@@ -113,7 +118,7 @@ void foo() {
 ```cpp
 #include <WiFi.h>
 #include "TinyGSM.h"
-#include "SSLClient.h"
+#include "SSLClientESP32.h"
 
 // Modem SIM7600G-H
 TinyGsm modem(Serial1);
@@ -121,7 +126,7 @@ TinyGsm modem(Serial1);
 // Create clients
 WiFiClient base_client_1, base_client_2;
 TinyGsmClient base_client_3(modem);
-SSLClient ssl_client(&base_client_1);
+SSLClientESP32 ssl_client(&base_client_1);
 
 void setup() {
   // Attach certificate...

--- a/library.json
+++ b/library.json
@@ -1,14 +1,14 @@
 {
-  "name": "SSLClient",
+  "name": "SSLClientESP32",
   "version": "2.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alkonosst/SSLClient.git"
+    "url": "https://github.com/alkonosst/SSLClientESP32.git"
   },
   "description": "Provides secure network connection over a generic Client transport object. With this library you can make a SSL/TLS connection to a remote server using any object of Client class, like WiFiClient or TinyGsmClient. Additionally, you can provide the SSLClient object with a Certificate Bundle, facilitating access to most websites.",
   "keywords": "secure, ssl, tls, gsm, arduino, esp32, client, wificlient, tinygsm, tinygsmclient, mbedtls",
-  "license": "GPL-3.0-or-later",
+  "license": "GPL-3.0 license",
   "frameworks": "arduino",
   "platforms": "espressif32",
-  "headers": "SSLClient.h"
+  "headers": "SSLClientESP32.h"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
-name=SSLClient
+name=SSLClientESP32
 version=2.0.0
 author=V Govorovski, Maximiliano Ramirez
 maintainer=Github Community
 sentence=Provides secure network connection over a generic Client transport object.
 paragraph=With this library you can make a SSL/TLS connection to a remote server using any object of Client class, like WiFiClient or TinyGsmClient. Additionally, you can provide the SSLClient object with a Certificate Bundle, facilitating access to most websites.
 category=Communication
-url=https://github.com/alkonosst/SSLClient
+url=https://github.com/alkonosst/SSLClientESP32
 architectures=esp32
-includes=SSLClient.h
+includes=SSLClientESP32.h

--- a/src/SSLClientESP32.cpp
+++ b/src/SSLClientESP32.cpp
@@ -1,5 +1,5 @@
 /*
-  SSLClient.cpp - Base class that provides Client SSL to ESP32
+  SSLClientESP32.cpp - Base class that provides Client SSL to ESP32
   Additions (c) 2011 Adrian McEwen.  All right reserved.
   Additions Copyright (C) 2017 Evandro Luis Copercini.
   Additions Copyright (C) 2019 Vadim Govorovski.
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "SSLClient.h"
+#include "SSLClientESP32.h"
 #include "esp_crt_bundle.h"
 #include <errno.h>
 
@@ -26,7 +26,7 @@
 #undef read
 
 
-SSLClient::SSLClient()
+SSLClientESP32::SSLClientESP32()
 {
     _connected = false;
 
@@ -43,7 +43,7 @@ SSLClient::SSLClient()
     _use_ca_bundle = false;
 }
 
-SSLClient::SSLClient(Client* client)
+SSLClientESP32::SSLClientESP32(Client* client)
 {
     _connected = false;
 
@@ -59,13 +59,13 @@ SSLClient::SSLClient(Client* client)
     _use_ca_bundle = false;
 }
 
-SSLClient::~SSLClient()
+SSLClientESP32::~SSLClientESP32()
 {
     stop();
     delete sslclient;
 }
 
-void SSLClient::stop()
+void SSLClientESP32::stop()
 {
     if (sslclient->client >= 0) {
         //sslclient->client->stop();
@@ -75,40 +75,40 @@ void SSLClient::stop()
     SSLClientLib::stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
 }
 
-void SSLClient::setClient(Client* client) {
+void SSLClientESP32::setClient(Client* client) {
     sslclient->client = client;
 }
 
-int SSLClient::connect(IPAddress ip, uint16_t port)
+int SSLClientESP32::connect(IPAddress ip, uint16_t port)
 {
     if (_pskIdent && _psKey)
         return connect(ip, port, _pskIdent, _psKey);
     return connect(ip, port, _CA_cert, _cert, _private_key);
 }
 
-int SSLClient::connect(IPAddress ip, uint16_t port, int32_t timeout){
+int SSLClientESP32::connect(IPAddress ip, uint16_t port, int32_t timeout){
     _timeout = timeout;
     return connect(ip, port);
 }
 
-int SSLClient::connect(const char *host, uint16_t port)
+int SSLClientESP32::connect(const char *host, uint16_t port)
 {
     if (_pskIdent && _psKey)
         return connect(host, port, _pskIdent, _psKey);
     return connect(host, port, _CA_cert, _cert, _private_key);
 }
 
-int SSLClient::connect(const char *host, uint16_t port, int32_t timeout){
+int SSLClientESP32::connect(const char *host, uint16_t port, int32_t timeout){
     _timeout = timeout;
     return connect(host, port);
 }
 
-int SSLClient::connect(IPAddress ip, uint16_t port, const char *CA_cert, const char *cert, const char *private_key)
+int SSLClientESP32::connect(IPAddress ip, uint16_t port, const char *CA_cert, const char *cert, const char *private_key)
 {
     return connect(ip.toString().c_str(), port, CA_cert, cert, private_key);
 }
 
-int SSLClient::connect(const char *host, uint16_t port, const char *CA_cert, const char *cert, const char *private_key)
+int SSLClientESP32::connect(const char *host, uint16_t port, const char *CA_cert, const char *cert, const char *private_key)
 {
     log_d("Connecting to %s:%d", host, port);
     if(_timeout > 0){
@@ -127,11 +127,11 @@ int SSLClient::connect(const char *host, uint16_t port, const char *CA_cert, con
     return 1;
 }
 
-int SSLClient::connect(IPAddress ip, uint16_t port, const char *pskIdent, const char *psKey) {
+int SSLClientESP32::connect(IPAddress ip, uint16_t port, const char *pskIdent, const char *psKey) {
     return connect(ip.toString().c_str(), port, pskIdent, psKey);
 }
 
-int SSLClient::connect(const char *host, uint16_t port, const char *pskIdent, const char *psKey) {
+int SSLClientESP32::connect(const char *host, uint16_t port, const char *pskIdent, const char *psKey) {
     log_v("start_ssl_client with PSK");
     if(_timeout > 0){
         sslclient->handshake_timeout = _timeout;
@@ -148,7 +148,7 @@ int SSLClient::connect(const char *host, uint16_t port, const char *pskIdent, co
     return 1;
 }
 
-int SSLClient::peek(){
+int SSLClientESP32::peek(){
     if(_peek >= 0){
         return _peek;
     }
@@ -156,12 +156,12 @@ int SSLClient::peek(){
     return _peek;
 }
 
-size_t SSLClient::write(uint8_t data)
+size_t SSLClientESP32::write(uint8_t data)
 {
     return write(&data, 1);
 }
 
-int SSLClient::read()
+int SSLClientESP32::read()
 {
     uint8_t data = -1;
     int res = read(&data, 1);
@@ -171,7 +171,7 @@ int SSLClient::read()
     return data;
 }
 
-size_t SSLClient::write(const uint8_t *buf, size_t size)
+size_t SSLClientESP32::write(const uint8_t *buf, size_t size)
 {
     if (!_connected) {
         return 0;
@@ -184,7 +184,7 @@ size_t SSLClient::write(const uint8_t *buf, size_t size)
     return res;
 }
 
-int SSLClient::read(uint8_t *buf, size_t size)
+int SSLClientESP32::read(uint8_t *buf, size_t size)
 {
     int peeked = 0;
     int avail = available();
@@ -214,7 +214,7 @@ int SSLClient::read(uint8_t *buf, size_t size)
     return res + peeked;
 }
 
-int SSLClient::available()
+int SSLClientESP32::available()
 {
     int peeked = (_peek >= 0);
     if (!_connected) {
@@ -228,7 +228,7 @@ int SSLClient::available()
     return res+peeked;
 }
 
-uint8_t SSLClient::connected()
+uint8_t SSLClientESP32::connected()
 {
     uint8_t dummy = 0;
     read(&dummy, 0);
@@ -236,7 +236,7 @@ uint8_t SSLClient::connected()
     return _connected;
 }
 
-void SSLClient::setInsecure()
+void SSLClientESP32::setInsecure()
 {
     _CA_cert = NULL;
     _cert = NULL;
@@ -246,12 +246,12 @@ void SSLClient::setInsecure()
     _use_insecure = true;   
 }
 
-void SSLClient::setCACert (const char *rootCA)
+void SSLClientESP32::setCACert (const char *rootCA)
 {
     _CA_cert = rootCA;
 }
 
-void SSLClient::setCACertBundle(const uint8_t * bundle)
+void SSLClientESP32::setCACertBundle(const uint8_t * bundle)
 {
     if (bundle != NULL)
     {
@@ -263,22 +263,22 @@ void SSLClient::setCACertBundle(const uint8_t * bundle)
     }
 }
 
-void SSLClient::setCertificate (const char *client_ca)
+void SSLClientESP32::setCertificate (const char *client_ca)
 {
     _cert = client_ca;
 }
 
-void SSLClient::setPrivateKey (const char *private_key)
+void SSLClientESP32::setPrivateKey (const char *private_key)
 {
     _private_key = private_key;
 }
 
-void SSLClient::setPreSharedKey(const char *pskIdent, const char *psKey) {
+void SSLClientESP32::setPreSharedKey(const char *pskIdent, const char *psKey) {
     _pskIdent = pskIdent;
     _psKey = psKey;
 }
 
-bool SSLClient::verify(const char* fp, const char* domain_name)
+bool SSLClientESP32::verify(const char* fp, const char* domain_name)
 {
     if (!sslclient)
         return false;
@@ -286,7 +286,7 @@ bool SSLClient::verify(const char* fp, const char* domain_name)
     return SSLClientLib::verify_ssl_fingerprint(sslclient, fp, domain_name);
 }
 
-char *SSLClient::_streamLoad(Stream& stream, size_t size) {
+char *SSLClientESP32::_streamLoad(Stream& stream, size_t size) {
   char *dest = (char*)malloc(size+1);
   if (!dest) {
     return nullptr;
@@ -300,7 +300,7 @@ char *SSLClient::_streamLoad(Stream& stream, size_t size) {
   return dest;
 }
 
-bool SSLClient::loadCACert(Stream& stream, size_t size) {
+bool SSLClientESP32::loadCACert(Stream& stream, size_t size) {
   if (_CA_cert != NULL) free(const_cast<char*>(_CA_cert));
   char *dest = _streamLoad(stream, size);
   bool ret = false;
@@ -311,7 +311,7 @@ bool SSLClient::loadCACert(Stream& stream, size_t size) {
   return ret;
 }
 
-bool SSLClient::loadCertificate(Stream& stream, size_t size) {
+bool SSLClientESP32::loadCertificate(Stream& stream, size_t size) {
   if (_cert != NULL) free(const_cast<char*>(_cert));
   char *dest = _streamLoad(stream, size);
   bool ret = false;
@@ -322,7 +322,7 @@ bool SSLClient::loadCertificate(Stream& stream, size_t size) {
   return ret;
 }
 
-bool SSLClient::loadPrivateKey(Stream& stream, size_t size) {
+bool SSLClientESP32::loadPrivateKey(Stream& stream, size_t size) {
   if (_private_key != NULL) free(const_cast<char*>(_private_key));
   char *dest = _streamLoad(stream, size);
   bool ret = false;
@@ -333,7 +333,7 @@ bool SSLClient::loadPrivateKey(Stream& stream, size_t size) {
   return ret;
 }
 
-int SSLClient::lastError(char *buf, const size_t size)
+int SSLClientESP32::lastError(char *buf, const size_t size)
 {
     if (!_lastError) {
         return 0;
@@ -342,12 +342,12 @@ int SSLClient::lastError(char *buf, const size_t size)
     return _lastError;
 }
 
-void SSLClient::setHandshakeTimeout(unsigned long handshake_timeout)
+void SSLClientESP32::setHandshakeTimeout(unsigned long handshake_timeout)
 {
     sslclient->handshake_timeout = handshake_timeout * 1000;
 }
 
-void SSLClient::setAlpnProtocols(const char **alpn_protos)
+void SSLClientESP32::setAlpnProtocols(const char **alpn_protos)
 {
     _alpn_protos = alpn_protos;
 }

--- a/src/SSLClientESP32.h
+++ b/src/SSLClientESP32.h
@@ -1,5 +1,5 @@
 /*
-  SSLClient.h - Base class that provides Client SSL to ESP32
+  SSLClientESP32.h - Base class that provides Client SSL to ESP32
   Additions (c) 2011 Adrian McEwen.  All right reserved.
   Additions Copyright (C) 2017 Evandro Luis Copercini.
   Additions Copyright (C) 2019 Vadim Govorovski.
@@ -17,13 +17,13 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef SSLClient_H
-#define SSLClient_H
+#ifndef SSLClientESP32_H
+#define SSLClientESP32_H
 #include "Arduino.h"
 #include "IPAddress.h"
 #include "ssl_client.h"
 
-class SSLClient : public Client
+class SSLClientESP32 : public Client
 {
 protected:
     SSLClientLib::sslclient_context *sslclient;
@@ -43,9 +43,9 @@ protected:
     bool _connected = false;
 
 public:
-    SSLClient();
-    SSLClient(Client* client);
-    ~SSLClient();
+    SSLClientESP32();
+    SSLClientESP32(Client* client);
+    ~SSLClientESP32();
 
     void setClient(Client* client);
     int connect(IPAddress ip, uint16_t port);
@@ -101,4 +101,4 @@ private:
     using Print::write;
 };
 
-#endif /* SSLClient_H */
+#endif /* SSLClientESP32_H */


### PR DESCRIPTION
## Description
Change library name from `SSLClient` to `SSLClientESP32` to allow upload library to Arduino Library Registry.

## Motivation and context
Arduino Library Registry doesn't allow to have duplicated library names, so we need to change this name a little to be accepted.