### PR TITLE
Fix definition conflict with wificlientsecure

### DIFF
--- a/examples/https_wifi_and_sim7600_certbundle/src/main.cpp
+++ b/examples/https_wifi_and_sim7600_certbundle/src/main.cpp
@@ -8,7 +8,7 @@
 #define TINY_GSM_RX_BUFFER 1024
 #define TINY_GSM_DEBUG     Serial
 
-#include "SSLClient.h"
+#include "SSLClientESP32.h"
 #include "TinyGSM.h"
 #include <Arduino.h>
 #include <WiFi.h>
@@ -36,7 +36,7 @@ WiFiClient client_wifi;
 TinyGsmClient client_modem(modem);
 
 // * Secure client object, initialized with Wifi client
-SSLClient ssl(&client_wifi);
+SSLClientESP32 ssl(&client_wifi);
 
 // * Certificate bundle with 41 most used root certificates
 extern const uint8_t ca_cert_bundle_start[] asm("_binary_data_crt_x509_crt_bundle_bin_start");

--- a/src/SSLClientESP32.cpp
+++ b/src/SSLClientESP32.cpp
@@ -18,7 +18,7 @@
 */
 
 #include "SSLClientESP32.h"
-#include "esp_crt_bundle.h"
+#include "ssl_lib_crt_bundle.h"
 #include <errno.h>
 
 #undef connect
@@ -257,10 +257,10 @@ void SSLClientESP32::setCACertBundle(const uint8_t * bundle)
 {
     if (bundle != NULL)
     {
-        arduino_esp_crt_bundle_set(bundle);
+        ssl_lib_crt_bundle_set(bundle);
         _use_ca_bundle = true;
     } else {
-        arduino_esp_crt_bundle_detach(NULL);
+        ssl_lib_crt_bundle_detach(NULL);
         _use_ca_bundle = false;
     }
 }

--- a/src/SSLClientESP32.h
+++ b/src/SSLClientESP32.h
@@ -17,11 +17,12 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef SSLClientESP32_H
-#define SSLClientESP32_H
+#ifndef SSLCLIENTESP32_H
+#define SSLCLIENTESP32_H
+
 #include "Arduino.h"
 #include "IPAddress.h"
-#include "ssl_client.h"
+#include "ssl_lib_client.h"
 
 class SSLClientESP32 : public Client
 {
@@ -101,4 +102,4 @@ private:
     using Print::write;
 };
 
-#endif /* SSLClientESP32_H */
+#endif /* SSLCLIENTESP32_H */

--- a/src/ssl_lib_client.cpp
+++ b/src/ssl_lib_client.cpp
@@ -13,8 +13,8 @@
 #include <mbedtls/oid.h>
 #include <algorithm>
 #include <string>
-#include "ssl_client.h"
-#include "esp_crt_bundle.h"
+#include "ssl_lib_client.h"
+#include "ssl_lib_crt_bundle.h"
 
 namespace SSLClientLib {
 
@@ -214,7 +214,7 @@ int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t p
         }
     } else if (useRootCABundle) {
         log_v("Attaching root CA cert bundle");
-        ret = arduino_esp_crt_bundle_attach(&ssl_client->ssl_conf);
+        ret = ssl_lib_crt_bundle_attach(&ssl_client->ssl_conf);
 
         if (ret < 0) {
             return handle_error(ret);

--- a/src/ssl_lib_client.h
+++ b/src/ssl_lib_client.h
@@ -4,8 +4,9 @@
  * Additions Copyright (C) 2023 Maximiliano Ramirez.
  */
 
-#ifndef SSLCLIENT_LIB_ARD_SSL_H
-#define SSLCLIENT_LIB_ARD_SSL_H
+#ifndef SSL_LIB_ARD_SSL_H
+#define SSL_LIB_ARD_SSL_H
+
 #include "mbedtls/platform.h"
 #include "mbedtls/net.h"
 #include "mbedtls/debug.h"
@@ -47,4 +48,4 @@ bool get_peer_fingerprint(sslclient_context *ssl_client, uint8_t sha256[32]);
 
 }
 
-#endif
+#endif // SSL_LIB_ARD_SSL_H

--- a/src/ssl_lib_crt_bundle.c
+++ b/src/ssl_lib_crt_bundle.c
@@ -16,8 +16,7 @@
 #include <string.h>
 #include <esp_system.h>
 #include <esp32-hal-log.h>
-#include "esp_crt_bundle.h"
-#include "esp_err.h"
+#include "ssl_lib_crt_bundle.h"
 
 #define BUNDLE_HEADER_OFFSET 2
 #define CRT_HEADER_OFFSET 4
@@ -176,7 +175,7 @@ static esp_err_t esp_crt_bundle_init(const uint8_t *x509_bundle)
     return ESP_OK;
 }
 
-esp_err_t arduino_esp_crt_bundle_attach(void *conf)
+esp_err_t ssl_lib_crt_bundle_attach(void *conf)
 {
     esp_err_t ret = ESP_OK;
     // If no bundle has been set by the user then use the bundle embedded in the binary
@@ -199,7 +198,7 @@ esp_err_t arduino_esp_crt_bundle_attach(void *conf)
     return ret;
 }
 
-void arduino_esp_crt_bundle_detach(mbedtls_ssl_config *conf)
+void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf)
 {
     free(s_crt_bundle.crts);
     s_crt_bundle.crts = NULL;
@@ -208,7 +207,7 @@ void arduino_esp_crt_bundle_detach(mbedtls_ssl_config *conf)
     }
 }
 
-void arduino_esp_crt_bundle_set(const uint8_t *x509_bundle)
+void ssl_lib_crt_bundle_set(const uint8_t *x509_bundle)
 {
     // Free any previously used bundle
     free(s_crt_bundle.crts);

--- a/src/ssl_lib_crt_bundle.h
+++ b/src/ssl_lib_crt_bundle.h
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 
-#ifndef _ESP_CRT_BUNDLE_H_
-#define _ESP_CRT_BUNDLE_H_
+#ifndef SSL_LIB_CRT_BUNDLE_H
+#define SSL_LIB_CRT_BUNDLE_H
 
 #include "mbedtls/ssl.h"
+#include "esp_err.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,7 @@ extern "C" {
  *             - ESP_OK  if adding certificates was successful.
  *             - Other   if an error occured or an action must be taken by the calling process.
  */
-esp_err_t arduino_esp_crt_bundle_attach(void *conf);
+esp_err_t ssl_lib_crt_bundle_attach(void *conf);
 
 
 /**
@@ -46,7 +47,7 @@ esp_err_t arduino_esp_crt_bundle_attach(void *conf);
  *
  * @param[in]  conf      The config struct for the SSL connection.
  */
-void arduino_esp_crt_bundle_detach(mbedtls_ssl_config *conf);
+void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf);
 
 
 /**
@@ -58,11 +59,11 @@ void arduino_esp_crt_bundle_detach(mbedtls_ssl_config *conf);
  *
  * @param[in]  x509_bundle     A pointer to the certificate bundle.
  */
-void arduino_esp_crt_bundle_set(const uint8_t *x509_bundle);
+void ssl_lib_crt_bundle_set(const uint8_t *x509_bundle);
 
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif //_ESP_CRT_BUNDLE_H_
+#endif //SSL_LIB_CRT_BUNDLE_H


### PR DESCRIPTION
## Description
Change file and object names due to conflict with `WiFiClientSecure`.

## Motivation and context
Fixes #7

## How this has been tested?
**Tested with**:
- Hardware: ESP32-WROVER-IE 16MB
- SSLClientESP32 version: v2.0.1